### PR TITLE
Extract from one selector

### DIFF
--- a/test/fixtures/should extract few same atRules in one selector/extracted.css
+++ b/test/fixtures/should extract few same atRules in one selector/extracted.css
@@ -1,0 +1,4 @@
+.selector {
+    width: 10px;
+    height: 10px
+}

--- a/test/fixtures/should extract few same atRules in one selector/input.css
+++ b/test/fixtures/should extract few same atRules in one selector/input.css
@@ -1,0 +1,8 @@
+.selector {
+    @important {
+        width: 10px;
+    }
+    @important {
+        height: 10px;
+    }
+}

--- a/test/fixtures/should extract few same atRules in one selector/output.css
+++ b/test/fixtures/should extract few same atRules in one selector/output.css
@@ -1,0 +1,2 @@
+.selector {
+}


### PR DESCRIPTION
It must not create additional selector when it is used inside one:

`input.css`:

``` css
.selector {
    @important {
        width: 10px;
    }
    @important {
        height: 10px;
    }
}
```

Expected `extracted.css`:

``` css
.selector {
    width: 10px;
    height: 10px
}
```

Actual:

``` css
.selector {
    width: 10px
}
.selector {
    height: 10px
}
```
