### PR TITLE
Fix all tests to run on Windows

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -46,8 +46,8 @@ describe('fixtures', () => {
       const input = getFile('input.css')
       const output = getFile('output.css')
       return run(input, output, options).then(() => {
-        const extracted = getFile('extracted.css')
-        const extractedActual = getFile('extracted-actual.css')
+        const extracted = getFile('extracted.css').replace(/\r\n|\n/g, '')
+        const extractedActual = getFile('extracted-actual.css').replace(/\r\n|\n/g, '')
         extracted.should.be.equal(extractedActual)
       })
     })


### PR DESCRIPTION
Hello

At the moment all tests fail on Windows due to LF issue [described here](https://en.wikipedia.org/wiki/Newline). Have a look at the attached screenshot 
![lf_tests_errors](https://cloud.githubusercontent.com/assets/428317/18175804/439f67a8-708c-11e6-893b-c865f654279e.png)
